### PR TITLE
Rename brand logo field and add taxonomy columns

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -478,7 +478,7 @@ All API responses follow a standardized format using `ResponseProtocol`:
   "name": "Apple",
   "slug": "apple",
   "description": "Think Different",
-  "logo": "brands/apple-logo.png",
+  "logo_url": "brands/apple-logo.png",
   "is_active": true
 }
 ```
@@ -521,7 +521,7 @@ All API responses follow a standardized format using `ResponseProtocol`:
     "name": "Apple",
     "slug": "apple",
     "description": "Think Different",
-    "logo": "brands/apple-logo.png",
+    "logo_url": "brands/apple-logo.png",
     "is_active": true,
     "created_at": "2024-01-01T00:00:00.000000Z",
     "updated_at": "2024-01-01T00:00:00.000000Z"
@@ -693,14 +693,29 @@ All API responses follow a standardized format using `ResponseProtocol`:
 **Response (201):**
 ```json
 {
-  "status": "success",
-  "message": "Category created successfully",
-  "data": {
-    "id": 2,
-    "name": "Laptops",
-    "slug": "laptops",
-    "parent_id": 1
-  }
+    "status": "success",
+    "message": "Category created successfully",
+    "data": {
+        "id": 2,
+        "name": "Laptops 2",
+        "slug": "laptops 2",
+        "description": "Portable computers 2",
+        "parent_id": 1,
+        "is_active": true,
+        "parent": {
+            "id": 1,
+            "name": "Laptops",
+            "slug": "laptops",
+            "description": "Portable computers",
+            "parent_id": null,
+            "is_active": true,
+            "created_at": "2025-11-26T21:20:26.000000Z",
+            "updated_at": "2025-11-26T21:20:26.000000Z"
+        },
+        "children": [],
+        "created_at": "2025-11-26T21:21:25.000000Z",
+        "updated_at": "2025-11-26T21:21:25.000000Z"
+    }
 }
 ```
 

--- a/database/migrations/2024_11_27_000001_add_is_active_to_taxonomy_types_table.php
+++ b/database/migrations/2024_11_27_000001_add_is_active_to_taxonomy_types_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('taxonomy_types', function (Blueprint $table) {
+            $table->boolean('is_active')->default(true)->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('taxonomy_types', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+    }
+};

--- a/database/migrations/2024_11_27_000002_add_sort_order_to_taxonomies_table.php
+++ b/database/migrations/2024_11_27_000002_add_sort_order_to_taxonomies_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('taxonomies', function (Blueprint $table) {
+            $table->integer('sort_order')->nullable()->after('parent_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('taxonomies', function (Blueprint $table) {
+            $table->dropColumn('sort_order');
+        });
+    }
+};

--- a/src/ECommerce/Product/Http/Requests/StoreBrandRequest.php
+++ b/src/ECommerce/Product/Http/Requests/StoreBrandRequest.php
@@ -25,7 +25,7 @@ class StoreBrandRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'slug' => ['required', 'string', 'max:255', 'unique:brands,slug'],
             'description' => ['nullable', 'string'],
-            'logo' => ['nullable', 'string', 'max:500'],
+            'logo_url' => ['nullable', 'string', 'max:500'],
             'is_active' => ['nullable', 'boolean'],
         ];
     }

--- a/src/ECommerce/Product/Http/Requests/UpdateBrandRequest.php
+++ b/src/ECommerce/Product/Http/Requests/UpdateBrandRequest.php
@@ -27,7 +27,7 @@ class UpdateBrandRequest extends FormRequest
             'name' => ['sometimes', 'required', 'string', 'max:255'],
             'slug' => ['nullable', 'string', 'max:255', 'unique:brands,slug,' . $brandId],
             'description' => ['nullable', 'string'],
-            'logo' => ['nullable', 'string', 'max:500'],
+            'logo_url' => ['nullable', 'string', 'max:500'],
             'is_active' => ['nullable', 'boolean'],
         ];
     }

--- a/src/ECommerce/Product/Http/Resources/BrandResource.php
+++ b/src/ECommerce/Product/Http/Resources/BrandResource.php
@@ -19,7 +19,7 @@ class BrandResource extends JsonResource
             'name' => $this->name,
             'slug' => $this->slug,
             'description' => $this->description,
-            'logo' => $this->logo ? asset('storage/' . $this->logo) : null,
+            'logo_url' => $this->logo_url ? asset('storage/' . $this->logo_url) : null,
             'is_active' => $this->is_active,
             'products_count' => $this->when($this->relationLoaded('products'), fn() => $this->products->count()),
             'created_at' => $this->created_at?->toISOString(),


### PR DESCRIPTION
Renamed the 'logo' field to 'logo_url' in brand API documentation, request validation, and resource output for consistency. Added 'is_active' column to 'taxonomy_types' and 'sort_order' column to 'taxonomies' via new migrations. Updated category creation response example in API documentation to include new fields.