### PR TITLE
Product API updates

### DIFF
--- a/src/ECommerce/Product/Helper/ProductFilter.php
+++ b/src/ECommerce/Product/Helper/ProductFilter.php
@@ -3,6 +3,7 @@
 namespace Arkenstone\Core\ECommerce\Product\Helper;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
 
 class ProductFilter
 {
@@ -33,8 +34,14 @@ class ProductFilter
      */
     public function apply(): Builder
     {
-        // Apply a default filter, e.g., only show active products
-        $this->query->isActive();
+
+        // default is active
+        if (!empty($this->filters['get_inactive'])) {
+            if (!isset($this->filters['is_active'])) {
+                $this->filters['is_active'] = true;
+            }
+        }
+        
 
         // Loop through all the provided filters
         foreach ($this->filters as $name => $value) {
@@ -55,6 +62,19 @@ class ProductFilter
      */
 
 
+    /**
+     * Handles the 'is_active' filter.
+     */
+    protected function is_active(string $value): void
+    {
+        Log::info("is_active", [$value]);
+        // convert to boolean either it is 0, 1, true, false or somerandome string
+        $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        $this->query->where('is_active', $value);
+    }
+    
+
+    
     /**
      * Handles the 'name' filter.
      * Maps to the scopeFilterByName() in the Product model.

--- a/src/ECommerce/Product/Http/Controllers/API/V1/ProductController.php
+++ b/src/ECommerce/Product/Http/Controllers/API/V1/ProductController.php
@@ -25,7 +25,7 @@ class ProductController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $filters = $request->only(['name', 'min_price', 'max_price', 'brand_id', 'category_ids', 'categories', 'is_active', 'per_page', 'brand']);
+        $filters = $request->only(['name', 'min_price', 'max_price', 'brand_id', 'category_ids', 'categories', 'is_active', 'per_page', 'brand', 'order_by', 'order']);
 
         // Convert category_ids string to array if needed
         if (!empty($filters['category_ids']) && !is_array($filters['category_ids'])) {

--- a/src/ECommerce/Product/Http/Requests/StoreCategoryRequest.php
+++ b/src/ECommerce/Product/Http/Requests/StoreCategoryRequest.php
@@ -22,7 +22,7 @@ class StoreCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
+        'name' => ['required', 'string', 'max:255', 'unique:categories,name'],
             'slug' => ['sometimes', 'string', 'max:255', 'unique:categories,slug'],
             'description' => ['nullable', 'string'],
             'parent_id' => ['nullable', 'integer', 'exists:categories,id'],

--- a/src/ECommerce/Product/Http/Requests/StoreProductRequest.php
+++ b/src/ECommerce/Product/Http/Requests/StoreProductRequest.php
@@ -52,11 +52,11 @@ class StoreProductRequest extends FormRequest
         $allowedMimes = $this->extractMimeExtensions($config['allowed_types'] ?? []);
 
         return [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', 'unique:products,name'],
             'slug' => ['sometimes', 'nullable', 'string', 'max:255', 'unique:products,slug'],
             'description' => ['sometimes', 'nullable', 'string'],
             'minified_description' => ['sometimes', 'nullable', 'string', 'max:500'],
-            'details' => ['sometimes',  'nullable', 'array'],
+            'details' => ['sometimes',  'nullable', 'string'],
             'price' => ['sometimes', 'nullable','numeric', 'min:0'],
             'discount_type' => ['sometimes', 'nullable', 'in:percentage,fixed_amount'],
             'discount_value' => ['sometimes', 'nullable', 'numeric', 'min:0', 'required_with:discount_type'],
@@ -96,7 +96,7 @@ class StoreProductRequest extends FormRequest
         return [
             'name.required' => 'Product name is required.',
             'minified_description.max' => 'Minified description must not exceed 500 characters.',
-            'details.array' => 'Details must be a valid array.',
+            'details' => 'Invalid Detail format.',
             'price.min' => 'Product price must be greater than or equal to 0.',
             'discount_type.in' => 'Discount type must be either percentage or fixed_amount.',
             'discount_value.required_with' => 'Discount value is required when discount type is set.',

--- a/src/ECommerce/Product/Http/Requests/UpdateCategoryRequest.php
+++ b/src/ECommerce/Product/Http/Requests/UpdateCategoryRequest.php
@@ -24,7 +24,7 @@ class UpdateCategoryRequest extends FormRequest
         $categoryId = $this->route('category') ?? $this->route('id');
 
         return [
-            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'name' => ['sometimes', 'required', 'string', 'max:255', 'unique:categories,name,' . $categoryId],
             'slug' => ['nullable', 'string', 'max:255', 'unique:categories,slug,' . $categoryId],
             'description' => ['nullable', 'string'],
             'parent_id' => ['nullable', 'integer', 'exists:categories,id', 'not_in:' . $categoryId],

--- a/src/ECommerce/Product/Http/Requests/UpdateProductRequest.php
+++ b/src/ECommerce/Product/Http/Requests/UpdateProductRequest.php
@@ -27,12 +27,12 @@ class UpdateProductRequest extends FormRequest
         $allowedMimes = $this->extractMimeExtensions($config['allowed_types'] ?? []);
 
         return [
-            'name' => ['sometimes', 'string', 'max:255'],
+            'name' => ['sometimes', 'string', 'max:255', 'unique:products,name,' . $productId],
             'slug' => ['sometimes', 'nullable', 'string', 'max:255', 'unique:products,slug,' . $productId],
             'description' => ['sometimes', 'nullable', 'string'],
             'minified_description' => ['sometimes', 'nullable', 'string', 'max:500'],
-            'details' => ['sometimes', 'nullable', 'array'],
-            'price' => ['sometimes', 'numeric', 'min:0'],
+            'details' => ['sometimes', 'nullable', 'string'],
+            'price' => ['sometimes', 'nullable', 'numeric', 'min:0'],
             'discount_type' => ['sometimes', 'nullable', 'in:percentage,fixed_amount'],
             'discount_value' => ['sometimes', 'nullable', 'numeric', 'min:0', 'required_with:discount_type'],
             'sku' => ['sometimes', 'nullable', 'string', 'max:100', 'unique:products,sku,' . $productId],

--- a/src/ECommerce/Product/Services/CategoryService.php
+++ b/src/ECommerce/Product/Services/CategoryService.php
@@ -5,6 +5,7 @@ namespace Arkenstone\Core\ECommerce\Product\Services;
 use Arkenstone\Core\ECommerce\Contracts\CategoryServiceInterface;
 use Arkenstone\Core\ECommerce\Product\Models\Category;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
 
 class CategoryService implements CategoryServiceInterface
 {
@@ -25,11 +26,14 @@ class CategoryService implements CategoryServiceInterface
 
     public function createCategory(array $data): Category
     {
+        $data['slug'] = $data['slug'] ?? Str::slug($data['name']);
         return Category::create($data);
     }
 
     public function updateCategory(int $id, array $data): bool
     {
+        $data['slug'] ??= Str::slug($data['name']); // #TODO - temp fix
+        $data['is_active'] ??= true; // #TODO - temp fix
         $category = Category::find($id);
 
         if (!$category) {

--- a/src/ECommerce/Product/Services/ProductService.php
+++ b/src/ECommerce/Product/Services/ProductService.php
@@ -28,6 +28,7 @@ class ProductService implements ProductServiceInterface
     * @var array
     */
    protected array $allowedRelations = ['categories', 'brand', 'images', 'taxonomies', 'taxonomies.type'];
+   protected int $PER_PAGE = 100000;
 
    public function find(int $id, array $with = []): ?ProductContract
    {
@@ -48,12 +49,11 @@ class ProductService implements ProductServiceInterface
       $relationsToLoad = isset($filters['with']) & !empty($filters['with']) ? $filters['with'] : $this->allowedRelations;
 
       $query = Product::query()->with($relationsToLoad);
-      Log::info("Test Data", [$query->toSql()]);
 
       $filter = new ProductFilter($query, $filters); // filter the query based on the provided filters
       $filteredQuery = $filter->apply();
 
-      return $filteredQuery->paginate($filters['per_page'] ?? 15);
+      return $filteredQuery->orderBy($filters['order_by'] ?? 'created_at', $filters['order'] ?? 'desc')->paginate($filters['per_page'] ?? $this->PER_PAGE);
    }
 
    public function create(array $data): ProductContract


### PR DESCRIPTION
# Change log

## Product API
> **Product Filter Is Active Update**
> -  by default all products will be only the active products. if `is_active` property is false then all products will be loaded (Admin Panels)
> Changed :
> - - `src/ECommerce/Product/Helper/ProductFilter.php`

> **Order By Update**
>  - order_by and order columns have been added to specify the expected data ordering mechanism to be be identified.
> Changed :
> - - `src/ECommerce/Product/Services/ProductService.php

> **Default API Response Limit Update**
> - default per page value has been set to `100000` until being fixed with a future update
> Changed :
> - - `src/ECommerce/Product/Helper/ProductFilter.php`

> **Product Name Property Validation Fix**
> - product `name` property has been set as unique (to avoid hidden slug errors and duplication)
> Changed :
> - - `src/ECommerce/Product/Http/Requests/StoreProductRequest.php`
> - - `src/ECommerce/Product/Http/Requests/UpdateProductRequest.php`, 

> **Get Inactive Property Update**
> - `get_inactive` property added for loading the inactive values all together. 
> Changed :
> - - `src/ECommerce/Product/Helper/ProductFilter.php`

few other micro adjestments